### PR TITLE
make chmod do nothing

### DIFF
--- a/src/compat.c
+++ b/src/compat.c
@@ -1793,11 +1793,7 @@ BOOL WINAPI SetCurrentDirectoryA(LPCSTR lpPathName)
 
 int _chmod(const char *filename, int mode)
 {
-    int result;
-    char *converted = dos_to_unix(filename);
-    result = chmod(converted, mode);
-    free(converted);
-    return result;
+    return 0;
 }
 
 int _access(const char *filename, int mode)


### PR DESCRIPTION
This is a Linux-specific fix. I am uncertain whether it would cause a problem on another OS.

### Problem:
- Host a game while (e.g.) maps/Estate/user.rul exists
- Game calls `chmod("maps/Estate/user.rul", 128)`
- user.rul is now unreadable (mode is --w------- on Linux)
- - the default is (-rw-rw-r--) which is good

Every call to chmod is 128, which makes no sense on Linux, and I don't know what it was intended to do on Windows.